### PR TITLE
fix(core): collect params lost in INSERT VALUES and wrapped exprs

### DIFF
--- a/crates/scythe-cli/tests/generated/test_params.rs
+++ b/crates/scythe-cli/tests/generated/test_params.rs
@@ -1274,6 +1274,230 @@ fn test_insert_all_columns() {
 }
 
 #[test]
+fn test_insert_coalesce_param_collected() {
+    // From: testing_data/params/insert_values/04_insert_coalesce_param.json
+    // "Insert whose value expression wraps a placeholder inside a function call: the param must still be collected and typed from the target column"
+    let schema_sql = &["CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, bio TEXT);"];
+
+    let query_sql = "-- @name InsertBio\n-- @returns :exec\nINSERT INTO users (bio) VALUES (COALESCE($1, 'unknown'));";
+
+    let catalog = scythe_core::catalog::Catalog::from_ddl(schema_sql).unwrap();
+    let query = scythe_core::parser::parse_query(query_sql).unwrap();
+    let analyzed = scythe_core::analyzer::analyze(&catalog, &query).unwrap();
+
+    assert_eq!(analyzed.name, "InsertBio", "query name");
+    assert_eq!(analyzed.command.to_string(), "exec", "query command");
+    assert_eq!(analyzed.params.len(), 1, "param count");
+    assert_eq!(analyzed.params[0].name, "bio", "param name");
+    assert_eq!(analyzed.params[0].neutral_type, "string", "param neutral_type for bio");
+    assert!(analyzed.params[0].nullable, "param nullable for bio");
+    assert_eq!(analyzed.params[0].position, 1, "param position for bio");
+
+    // Codegen verification: all backends should produce valid output
+    let all_backends = [
+        "rust-sqlx",
+        "rust-tokio-postgres",
+        "python-psycopg3",
+        "python-asyncpg",
+        "typescript-postgres",
+        "typescript-pg",
+        "typescript-kysely",
+        "go-pgx",
+        "java-jdbc",
+        "java-r2dbc",
+        "kotlin-exposed",
+        "kotlin-jdbc",
+        "kotlin-r2dbc",
+        "csharp-npgsql",
+        "elixir-postgrex",
+        "elixir-ecto",
+        "ruby-pg",
+        "ruby-trilogy",
+        "php-pdo",
+        "php-amphp",
+    ];
+    for backend_name in &all_backends {
+        let backend = match scythe_codegen::get_backend(backend_name, "postgresql") {
+            Ok(b) => b,
+            Err(_) => continue, // skip unregistered backends
+        };
+        if let Ok(generated) = scythe_codegen::generate_with_backend(&analyzed, &*backend) {
+            let header = backend.file_header();
+            let mut code = if header.is_empty() {
+                String::from("#![allow(dead_code, unused_imports)]\n")
+            } else {
+                let mut h = header;
+                h.push('\n');
+                h
+            };
+            if let Some(ref s) = generated.enum_def {
+                code.push_str(s);
+                code.push('\n');
+            }
+            if let Some(ref s) = generated.model_struct {
+                code.push_str(s);
+                code.push('\n');
+            }
+            if let Some(ref s) = generated.row_struct {
+                code.push_str(s);
+                code.push('\n');
+            }
+            if let Some(ref s) = generated.query_fn {
+                code.push_str(s);
+                code.push('\n');
+            }
+            if code.lines().count() > 1 {
+                // Only validate Rust syntax with syn for Rust backends
+                if *backend_name == "rust-sqlx" || *backend_name == "rust-tokio-postgres" {
+                    assert!(
+                        syn::parse_file(&code).is_ok(),
+                        "backend {} generated invalid Rust for {}",
+                        backend_name,
+                        "insert_coalesce_param_collected"
+                    );
+                } else {
+                    // Structural validation for non-Rust backends
+                    let errors = scythe_codegen::validation::validate_structural(&code, backend_name);
+                    assert!(
+                        errors.is_empty(),
+                        "backend {} structural validation failed for {}: {:?}",
+                        backend_name,
+                        "insert_coalesce_param_collected",
+                        errors
+                    );
+                }
+            }
+            assert!(
+                generated.query_fn.is_some(),
+                "backend {} should produce query_fn for {}",
+                backend_name,
+                "insert_coalesce_param_collected"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_insert_no_column_list_positional_binding() {
+    // From: testing_data/params/insert_values/03_insert_no_column_list.json
+    // "Insert without a column list binds values positionally to the table's catalog columns, so params must be typed and named from that ordering"
+    let schema_sql =
+        &["CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL, age INTEGER);"];
+
+    let query_sql = "-- @name CreateUserNoColumns\n-- @returns :exec\nINSERT INTO users VALUES ($1, $2, $3, $4);";
+
+    let catalog = scythe_core::catalog::Catalog::from_ddl(schema_sql).unwrap();
+    let query = scythe_core::parser::parse_query(query_sql).unwrap();
+    let analyzed = scythe_core::analyzer::analyze(&catalog, &query).unwrap();
+
+    assert_eq!(analyzed.name, "CreateUserNoColumns", "query name");
+    assert_eq!(analyzed.command.to_string(), "exec", "query command");
+    assert_eq!(analyzed.params.len(), 4, "param count");
+    assert_eq!(analyzed.params[0].name, "id", "param name");
+    assert_eq!(analyzed.params[0].neutral_type, "int32", "param neutral_type for id");
+    assert!(!analyzed.params[0].nullable, "param nullable for id");
+    assert_eq!(analyzed.params[0].position, 1, "param position for id");
+    assert_eq!(analyzed.params[1].name, "name", "param name");
+    assert_eq!(analyzed.params[1].neutral_type, "string", "param neutral_type for name");
+    assert!(!analyzed.params[1].nullable, "param nullable for name");
+    assert_eq!(analyzed.params[1].position, 2, "param position for name");
+    assert_eq!(analyzed.params[2].name, "email", "param name");
+    assert_eq!(
+        analyzed.params[2].neutral_type, "string",
+        "param neutral_type for email"
+    );
+    assert!(!analyzed.params[2].nullable, "param nullable for email");
+    assert_eq!(analyzed.params[2].position, 3, "param position for email");
+    assert_eq!(analyzed.params[3].name, "age", "param name");
+    assert_eq!(analyzed.params[3].neutral_type, "int32", "param neutral_type for age");
+    assert!(analyzed.params[3].nullable, "param nullable for age");
+    assert_eq!(analyzed.params[3].position, 4, "param position for age");
+
+    // Codegen verification: all backends should produce valid output
+    let all_backends = [
+        "rust-sqlx",
+        "rust-tokio-postgres",
+        "python-psycopg3",
+        "python-asyncpg",
+        "typescript-postgres",
+        "typescript-pg",
+        "typescript-kysely",
+        "go-pgx",
+        "java-jdbc",
+        "java-r2dbc",
+        "kotlin-exposed",
+        "kotlin-jdbc",
+        "kotlin-r2dbc",
+        "csharp-npgsql",
+        "elixir-postgrex",
+        "elixir-ecto",
+        "ruby-pg",
+        "ruby-trilogy",
+        "php-pdo",
+        "php-amphp",
+    ];
+    for backend_name in &all_backends {
+        let backend = match scythe_codegen::get_backend(backend_name, "postgresql") {
+            Ok(b) => b,
+            Err(_) => continue, // skip unregistered backends
+        };
+        if let Ok(generated) = scythe_codegen::generate_with_backend(&analyzed, &*backend) {
+            let header = backend.file_header();
+            let mut code = if header.is_empty() {
+                String::from("#![allow(dead_code, unused_imports)]\n")
+            } else {
+                let mut h = header;
+                h.push('\n');
+                h
+            };
+            if let Some(ref s) = generated.enum_def {
+                code.push_str(s);
+                code.push('\n');
+            }
+            if let Some(ref s) = generated.model_struct {
+                code.push_str(s);
+                code.push('\n');
+            }
+            if let Some(ref s) = generated.row_struct {
+                code.push_str(s);
+                code.push('\n');
+            }
+            if let Some(ref s) = generated.query_fn {
+                code.push_str(s);
+                code.push('\n');
+            }
+            if code.lines().count() > 1 {
+                // Only validate Rust syntax with syn for Rust backends
+                if *backend_name == "rust-sqlx" || *backend_name == "rust-tokio-postgres" {
+                    assert!(
+                        syn::parse_file(&code).is_ok(),
+                        "backend {} generated invalid Rust for {}",
+                        backend_name,
+                        "insert_no_column_list_positional_binding"
+                    );
+                } else {
+                    // Structural validation for non-Rust backends
+                    let errors = scythe_codegen::validation::validate_structural(&code, backend_name);
+                    assert!(
+                        errors.is_empty(),
+                        "backend {} structural validation failed for {}: {:?}",
+                        backend_name,
+                        "insert_no_column_list_positional_binding",
+                        errors
+                    );
+                }
+            }
+            assert!(
+                generated.query_fn.is_some(),
+                "backend {} should produce query_fn for {}",
+                backend_name,
+                "insert_no_column_list_positional_binding"
+            );
+        }
+    }
+}
+
+#[test]
 fn test_insert_basic_returning() {
     // From: testing_data/params/insert_values/01_insert_basic.json
     // "Insert with two string params and RETURNING id"

--- a/crates/scythe-core/src/analyzer/mod.rs
+++ b/crates/scythe-core/src/analyzer/mod.rs
@@ -336,6 +336,126 @@ INSERT INTO users (name, email) VALUES ($1, $2) RETURNING id, name, email;",
         assert_eq!(result.params[1].neutral_type, "string");
     }
 
+    /// `INSERT INTO t VALUES (...)` with no column list binds positionally to
+    /// every column of the table in catalog order. Placeholders must be typed
+    /// and named from that ordering, not dropped (regression: F2 — params in a
+    /// column-list-less INSERT were silently lost).
+    #[test]
+    fn test_insert_without_column_list_binds_to_catalog_columns() {
+        let catalog = make_catalog();
+        let query = parse_query(
+            "-- @name CreateUserFull
+-- @returns :exec
+INSERT INTO users VALUES ($1, $2, $3, $4, $5, $6, $7, $8);",
+        )
+        .unwrap();
+        let result = analyze(&catalog, &query).unwrap();
+        assert_eq!(result.params.len(), 8, "all 8 placeholders must be registered");
+        let names: Vec<&str> = result.params.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(
+            names,
+            ["id", "name", "email", "age", "active", "created_at", "bio", "score"]
+        );
+        assert_eq!(result.params[0].neutral_type, "int32");
+        assert_eq!(result.params[1].neutral_type, "string");
+        assert_eq!(result.params[3].neutral_type, "int32");
+        assert_eq!(result.params[4].neutral_type, "bool");
+        assert_eq!(result.params[5].neutral_type, "datetime_tz");
+        assert_eq!(result.params[7].neutral_type, "decimal");
+        assert!(!result.params[1].nullable, "name is NOT NULL");
+        assert!(result.params[3].nullable, "age is nullable");
+        assert!(result.params[6].nullable, "bio is nullable");
+    }
+
+    /// When neither a column list nor a catalog entry is available, params in a
+    /// column-list-less INSERT must still be registered with an inferred type
+    /// rather than silently dropped.
+    #[test]
+    fn test_insert_without_column_list_unknown_table_registers_inferred_params() {
+        let catalog = make_catalog();
+        let query = parse_query(
+            "-- @name InsertNoSchema
+-- @returns :exec
+INSERT INTO t VALUES ($1, $2::text);",
+        )
+        .unwrap();
+        let result = analyze(&catalog, &query).unwrap();
+        assert_eq!(result.params.len(), 2, "$1 and $2 must both be registered");
+        assert_eq!(result.params[0].position, 1);
+        assert_eq!(result.params[0].name, "p1");
+        assert_eq!(result.params[1].position, 2);
+        assert_eq!(result.params[1].neutral_type, "string", "$2::text must infer as string");
+    }
+
+    /// An explicit column list still names params even when the table has no
+    /// catalog entry — only the type falls back to inference.
+    #[test]
+    fn test_insert_explicit_columns_unknown_table_keeps_declared_names() {
+        let catalog = make_catalog();
+        let query = parse_query(
+            "-- @name InsertNoSchemaCols
+-- @returns :exec
+INSERT INTO t (a, b) VALUES ($1, $2);",
+        )
+        .unwrap();
+        let result = analyze(&catalog, &query).unwrap();
+        assert_eq!(result.params.len(), 2);
+        assert_eq!(result.params[0].name, "a");
+        assert_eq!(result.params[1].name, "b");
+    }
+
+    /// Placeholders nested inside function calls in INSERT VALUES must be
+    /// collected (regression: F10 — the `_ => {}` arm swallowed them).
+    #[test]
+    fn test_insert_coalesce_param_collected() {
+        let catalog = make_catalog();
+        let query = parse_query(
+            "-- @name InsertBio
+-- @returns :exec
+INSERT INTO users (bio) VALUES (COALESCE($1, 'unknown'));",
+        )
+        .unwrap();
+        let result = analyze(&catalog, &query).unwrap();
+        assert_eq!(result.params.len(), 1, "$1 inside COALESCE must be registered");
+        assert_eq!(result.params[0].name, "bio");
+        assert_eq!(result.params[0].neutral_type, "string");
+        assert!(result.params[0].nullable, "bio is nullable");
+    }
+
+    /// Placeholders inside CASE branches of INSERT VALUES must be collected.
+    #[test]
+    fn test_insert_case_param_collected() {
+        let catalog = make_catalog();
+        let query = parse_query(
+            "-- @name InsertName
+-- @returns :exec
+INSERT INTO users (name) VALUES (CASE WHEN $1 THEN 'x' ELSE 'y' END);",
+        )
+        .unwrap();
+        let result = analyze(&catalog, &query).unwrap();
+        assert_eq!(result.params.len(), 1, "$1 inside CASE must be registered");
+        assert_eq!(result.params[0].name, "name");
+        assert_eq!(result.params[0].neutral_type, "string");
+    }
+
+    /// Placeholders nested in function calls in UPDATE SET must be collected.
+    #[test]
+    fn test_update_function_arg_param_collected() {
+        let catalog = make_catalog();
+        let query = parse_query(
+            "-- @name RenameUser
+-- @returns :exec
+UPDATE users SET name = LOWER(CONCAT($1, '_suffix')) WHERE id = $2;",
+        )
+        .unwrap();
+        let result = analyze(&catalog, &query).unwrap();
+        assert_eq!(result.params.len(), 2, "$1 in nested function args must be registered");
+        assert_eq!(result.params[0].name, "name");
+        assert_eq!(result.params[0].neutral_type, "string");
+        assert_eq!(result.params[1].name, "id");
+        assert_eq!(result.params[1].neutral_type, "int32");
+    }
+
     #[test]
     fn test_coalesce_nullability() {
         let catalog = make_catalog();

--- a/crates/scythe-core/src/analyzer/params.rs
+++ b/crates/scythe-core/src/analyzer/params.rs
@@ -286,6 +286,28 @@ impl<'a> Analyzer<'a> {
                 self.collect_param_from_expr_with_type_nullable(left, type_str, name, nullable);
                 self.collect_param_from_expr_with_type_nullable(right, type_str, name, nullable);
             }
+            Expr::Function(func) => {
+                for arg in self.get_function_args(func) {
+                    self.collect_param_from_expr_with_type_nullable(&arg, type_str, name, nullable);
+                }
+            }
+            Expr::Case {
+                operand,
+                conditions,
+                else_result,
+                ..
+            } => {
+                if let Some(op) = operand {
+                    self.collect_param_from_expr_with_type_nullable(op, type_str, name, nullable);
+                }
+                for case_when in conditions {
+                    self.collect_param_from_expr_with_type_nullable(&case_when.condition, type_str, name, nullable);
+                    self.collect_param_from_expr_with_type_nullable(&case_when.result, type_str, name, nullable);
+                }
+                if let Some(else_expr) = else_result {
+                    self.collect_param_from_expr_with_type_nullable(else_expr, type_str, name, nullable);
+                }
+            }
             _ => {}
         }
     }

--- a/crates/scythe-core/src/analyzer/statements.rs
+++ b/crates/scythe-core/src/analyzer/statements.rs
@@ -324,14 +324,42 @@ impl<'a> Analyzer<'a> {
     ) -> Result<(), ScytheError> {
         match source {
             SetExpr::Values(values) => {
+                // Resolve the column each VALUES position binds to: the explicit
+                // column list, or — when omitted — every column of the table in
+                // catalog order (standard SQL positional binding for
+                // `INSERT INTO t VALUES (...)`). A position with no known column
+                // falls back to inferring the expression's own type, so
+                // placeholders are never dropped silently.
+                let effective_cols: Vec<Option<(String, String, bool)>> = if target_cols.is_empty() {
+                    match self.catalog.get_table(table_name) {
+                        Some(table) => table
+                            .columns
+                            .iter()
+                            .map(|c| Some((c.name.clone(), self.get_column_type(table_name, &c.name)?, c.nullable)))
+                            .collect(),
+                        None => Vec::new(),
+                    }
+                } else {
+                    target_cols
+                        .iter()
+                        .map(|n| {
+                            Some((
+                                n.clone(),
+                                self.get_column_type(table_name, n)?,
+                                self.is_column_nullable(table_name, n),
+                            ))
+                        })
+                        .collect()
+                };
+
                 for row in &values.rows {
                     for (i, expr) in row.iter().enumerate() {
-                        if i < target_cols.len() {
-                            let col_name = &target_cols[i];
-                            if let Some(col_type) = self.get_column_type(table_name, col_name) {
-                                let nullable = self.is_column_nullable(table_name, col_name);
-                                self.collect_param_from_expr_with_type_nullable(expr, &col_type, col_name, nullable);
-                            }
+                        if let Some((col_name, col_type, nullable)) = effective_cols.get(i).and_then(|c| c.as_ref()) {
+                            self.collect_param_from_expr_with_type_nullable(expr, col_type, col_name, *nullable);
+                        } else {
+                            let ti = self.infer_expr_type(expr, &Scope { sources: Vec::new() });
+                            let name = target_cols.get(i).cloned().unwrap_or_else(|| expr_to_name(expr));
+                            self.collect_param_from_expr_with_type_nullable(expr, &ti.neutral_type, &name, ti.nullable);
                         }
                     }
                 }

--- a/testing_data/params/insert_values/03_insert_no_column_list.json
+++ b/testing_data/params/insert_values/03_insert_no_column_list.json
@@ -1,0 +1,49 @@
+{
+  "category": "params/insert_values",
+  "config": {
+    "engine": "postgresql",
+    "gen": {
+      "target": "sqlx"
+    }
+  },
+  "description": "Insert without a column list binds values positionally to the table's catalog columns, so params must be typed and named from that ordering",
+  "expected": {
+    "query": {
+      "columns": [],
+      "command": "exec",
+      "name": "CreateUserNoColumns",
+      "params": [
+        {
+          "name": "id",
+          "nullable": false,
+          "type": "int32",
+          "position": 1
+        },
+        {
+          "name": "name",
+          "nullable": false,
+          "type": "string",
+          "position": 2
+        },
+        {
+          "name": "email",
+          "nullable": false,
+          "type": "string",
+          "position": 3
+        },
+        {
+          "name": "age",
+          "nullable": true,
+          "type": "int32",
+          "position": 4
+        }
+      ]
+    },
+    "success": true
+  },
+  "name": "insert_no_column_list_positional_binding",
+  "query_sql": "-- @name CreateUserNoColumns\n-- @returns :exec\nINSERT INTO users VALUES ($1, $2, $3, $4);",
+  "schema_sql": ["CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL, age INTEGER);"],
+  "source": "sqlc",
+  "tags": ["param", "insert", "no_column_list", "regression"]
+}

--- a/testing_data/params/insert_values/04_insert_coalesce_param.json
+++ b/testing_data/params/insert_values/04_insert_coalesce_param.json
@@ -1,0 +1,31 @@
+{
+  "category": "params/insert_values",
+  "config": {
+    "engine": "postgresql",
+    "gen": {
+      "target": "sqlx"
+    }
+  },
+  "description": "Insert whose value expression wraps a placeholder inside a function call: the param must still be collected and typed from the target column",
+  "expected": {
+    "query": {
+      "columns": [],
+      "command": "exec",
+      "name": "InsertBio",
+      "params": [
+        {
+          "name": "bio",
+          "nullable": true,
+          "type": "string",
+          "position": 1
+        }
+      ]
+    },
+    "success": true
+  },
+  "name": "insert_coalesce_param_collected",
+  "query_sql": "-- @name InsertBio\n-- @returns :exec\nINSERT INTO users (bio) VALUES (COALESCE($1, 'unknown'));",
+  "schema_sql": ["CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, bio TEXT);"],
+  "source": "sqlc",
+  "tags": ["param", "insert", "coalesce", "regression"]
+}


### PR DESCRIPTION
## Summary

This PR addresses two gaps in the analyzer's parameter collection that I noticed while reading the code. In both cases placeholders (`$N`) in certain DML statements were silently dropped from the analyzed params — the generated code would compile, but would fail at runtime with missing-argument errors.

I'm not very familiar with this codebase yet, so please treat this as a proposal: I'm happy to adjust naming, approach, or scope based on your feedback.

## Problem 1: `INSERT ... VALUES` without a column list dropped all params

`INSERT INTO users VALUES ($1, $2, ...)` (no explicit column list) registered no params at all:

- In `collect_insert_params`, the `SetExpr::Values` branch only walked a row when the position index was inside the explicit `target_cols` list. With an empty list the loop body never ran, so every placeholder was silently lost.
- Example: `INSERT INTO users VALUES ($1, $2, $3, $4)` would generate a function taking no parameters.

**Fix:** when the column list is omitted, each VALUES position now binds to the table's columns in catalog order — the standard SQL positional binding for this form. Placeholders are typed, named, and get nullability from those columns. If the table has no catalog entry either, the expression's own type is inferred (`infer_expr_type`), so the placeholder is still registered instead of dropped.

## Problem 2: params inside function calls / CASE in INSERT/UPDATE value expressions were swallowed

`collect_param_from_expr_with_type_nullable` (used for INSERT VALUES and UPDATE SET value expressions) matched only `Value`/`Cast`/`Nested`/`UnaryOp`/`BinaryOp` and fell through to a catch-all `_ => {}` arm for everything else:

- `INSERT INTO users (bio) VALUES (COALESCE($1, 'unknown'))` → `$1` never registered
- `UPDATE users SET name = CONCAT($1, '_suffix') WHERE id = $2` → only `$2` registered

**Fix:** a `Function` arm now recurses into the function's arguments (covering `COALESCE`, `CONCAT`, nested calls, ...), and a `Case` arm recurses into operand, conditions, results, and else branch. Params keep the target column's type/name/nullability, matching how the existing `BinaryOp` handling propagates them.

## Behavior change

Strictly additive: only queries whose params were previously dropped are affected — those would have failed at runtime anyway. No existing fixture expectations changed.

## Testing

- 6 new analyzer unit tests in `crates/scythe-core` (positional binding, unknown-table fallback, explicit columns without catalog, COALESCE/CASE in INSERT, nested function args in UPDATE).
- 2 new fixtures under `testing_data/params/insert_values/` with generated integration tests, which include a codegen smoke check across all 20 backends.
- Verified locally: `cargo test --workspace` (all green), `cargo clippy --workspace --all-targets -- -D warnings` (clean), `cargo fmt --all --check` (clean).

## Notes / decisions you may want to weigh in on

- **Fixture regeneration:** running `test-generator` rewrites every generated file (the committed ones are formatted in an older layout). To keep this PR focused I reverted that churn and added only the two new generated tests in the generator's current output format. A future full regeneration will reformat the whole directory.
- **Fallback naming:** when neither a column list nor a catalog entry exists, inferred params are named `p1`, `p2`, ... — consistent with the analyzer's existing fallback naming in `analyze()`.

Thanks for maintaining this project — the CONTRIBUTING guidelines and the fixture/test-generator workflow made it easy to get started.
