### PR TITLE
fix(core): apply CTE column alias lists to the analyzed scope

### DIFF
--- a/crates/scythe-cli/tests/generated/test_cte.rs
+++ b/crates/scythe-cli/tests/generated/test_cte.rs
@@ -279,6 +279,330 @@ fn test_simple_cte() {
 }
 
 #[test]
+fn test_cte_column_alias_count_mismatch() {
+    // From: testing_data/cte/column_alias/03_cte_column_alias_count_mismatch.json
+    // "CTE column alias list whose entry count disagrees with the body's column count must be rejected, matching PostgreSQL"
+    let schema_sql = &["CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)"];
+
+    let query_sql = "-- @name GetMismatch\n-- @returns :many\nWITH t(a) AS (SELECT 1, 2) SELECT * FROM t";
+
+    let catalog_result = scythe_core::catalog::Catalog::from_ddl(schema_sql);
+    if let Ok(catalog) = catalog_result {
+        let query_result = scythe_core::parser::parse_query(query_sql);
+        if let Ok(query) = query_result {
+            let result = scythe_core::analyzer::analyze(&catalog, &query);
+            assert!(result.is_err(), "expected analysis to fail");
+            let err = result.unwrap_err();
+            let err_msg = err.to_string();
+            assert!(
+                err_msg.contains("COLUMN_COUNT_MISMATCH"),
+                "error should contain code {:?}, got: {}",
+                "COLUMN_COUNT_MISMATCH",
+                err_msg
+            );
+            assert!(
+                err_msg.contains("CTE column alias list has 1 entries but the CTE body produces 2 columns"),
+                "error should contain {:?}, got: {}",
+                "CTE column alias list has 1 entries but the CTE body produces 2 columns",
+                err_msg
+            );
+        } else {
+            // Parse failed -- that counts as expected failure.
+            let err = query_result.unwrap_err();
+            let err_msg = err.to_string();
+            assert!(
+                err_msg.contains("COLUMN_COUNT_MISMATCH"),
+                "error should contain code {:?}, got: {}",
+                "COLUMN_COUNT_MISMATCH",
+                err_msg
+            );
+            assert!(
+                err_msg.contains("CTE column alias list has 1 entries but the CTE body produces 2 columns"),
+                "error should contain {:?}, got: {}",
+                "CTE column alias list has 1 entries but the CTE body produces 2 columns",
+                err_msg
+            );
+        }
+    } else {
+        // DDL processing failed -- that counts as expected failure.
+        let err = catalog_result.unwrap_err();
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("COLUMN_COUNT_MISMATCH"),
+            "error should contain code {:?}, got: {}",
+            "COLUMN_COUNT_MISMATCH",
+            err_msg
+        );
+        assert!(
+            err_msg.contains("CTE column alias list has 1 entries but the CTE body produces 2 columns"),
+            "error should contain {:?}, got: {}",
+            "CTE column alias list has 1 entries but the CTE body produces 2 columns",
+            err_msg
+        );
+    }
+}
+
+#[test]
+fn test_cte_column_alias_literals() {
+    // From: testing_data/cte/column_alias/01_cte_column_alias_literals.json
+    // "CTE with an explicit column alias list over a literal-only projection: the aliases must name the columns instead of the body's placeholder 'unknown' names"
+    let schema_sql = &["CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)"];
+
+    let query_sql = "-- @name GetPair\n-- @returns :many\nWITH t(a, b) AS (SELECT 1, 2) SELECT * FROM t";
+
+    let catalog = scythe_core::catalog::Catalog::from_ddl(schema_sql).unwrap();
+    let query = scythe_core::parser::parse_query(query_sql).unwrap();
+    let analyzed = scythe_core::analyzer::analyze(&catalog, &query).unwrap();
+
+    assert_eq!(analyzed.name, "GetPair", "query name");
+    assert_eq!(analyzed.command.to_string(), "many", "query command");
+    assert_eq!(analyzed.columns.len(), 2, "column count");
+    assert_eq!(analyzed.columns[0].name, "a", "column name");
+    assert_eq!(analyzed.columns[0].neutral_type, "int64", "column neutral_type for a");
+    assert!(!analyzed.columns[0].nullable, "column nullable for a");
+    assert_eq!(analyzed.columns[1].name, "b", "column name");
+    assert_eq!(analyzed.columns[1].neutral_type, "int64", "column neutral_type for b");
+    assert!(!analyzed.columns[1].nullable, "column nullable for b");
+
+    // Codegen verification: all backends should produce valid output
+    let all_backends = [
+        "rust-sqlx",
+        "rust-tokio-postgres",
+        "python-psycopg3",
+        "python-asyncpg",
+        "typescript-postgres",
+        "typescript-pg",
+        "typescript-kysely",
+        "go-pgx",
+        "java-jdbc",
+        "java-r2dbc",
+        "kotlin-exposed",
+        "kotlin-jdbc",
+        "kotlin-r2dbc",
+        "csharp-npgsql",
+        "elixir-postgrex",
+        "elixir-ecto",
+        "ruby-pg",
+        "ruby-trilogy",
+        "php-pdo",
+        "php-amphp",
+    ];
+    for backend_name in &all_backends {
+        let backend = match scythe_codegen::get_backend(backend_name, "postgresql") {
+            Ok(b) => b,
+            Err(_) => continue, // skip unregistered backends
+        };
+        if let Ok(generated) = scythe_codegen::generate_with_backend(&analyzed, &*backend) {
+            let preamble = backend.file_preamble();
+            let header = backend.file_header();
+            let mut body = String::new();
+            if header.is_empty() {
+                body.push_str("#![allow(dead_code, unused_imports)]\n");
+            } else {
+                body.push_str(&header);
+                body.push('\n');
+            }
+            if let Some(ref s) = generated.enum_def {
+                body.push_str(s);
+                body.push('\n');
+            }
+            for def in &generated.nested_struct_defs {
+                body.push_str(&def.code);
+                body.push('\n');
+            }
+            if let Some(ref s) = generated.model_struct {
+                body.push_str(s);
+                body.push('\n');
+            }
+            if let Some(ref s) = generated.row_struct {
+                body.push_str(s);
+                body.push('\n');
+            }
+            if let Some(ref s) = generated.query_fn {
+                body.push_str(s);
+                body.push('\n');
+            }
+            let code = scythe_codegen::provenance::assemble_file(
+                &preamble,
+                &scythe_codegen::provenance::header_line(
+                    &*backend,
+                    env!("CARGO_PKG_VERSION"),
+                    "postgresql",
+                    "sch1:0123456789abcdef",
+                ),
+                &body,
+            );
+            if body.lines().count() > 1 {
+                // Only validate Rust syntax with syn for Rust backends
+                if *backend_name == "rust-sqlx" || *backend_name == "rust-tokio-postgres" {
+                    assert!(
+                        syn::parse_file(&code).is_ok(),
+                        "backend {} generated invalid Rust for {}",
+                        backend_name,
+                        "cte_column_alias_literals"
+                    );
+                } else {
+                    // Structural validation for non-Rust backends
+                    let errors = scythe_codegen::validation::validate_structural(&code, backend_name);
+                    assert!(
+                        errors.is_empty(),
+                        "backend {} structural validation failed for {}: {:?}",
+                        backend_name,
+                        "cte_column_alias_literals",
+                        errors
+                    );
+                }
+            }
+            assert!(
+                generated.row_struct.is_some() || generated.model_struct.is_some(),
+                "backend {} should produce a struct for {}",
+                backend_name,
+                "cte_column_alias_literals"
+            );
+            assert!(
+                generated.query_fn.is_some(),
+                "backend {} should produce query_fn for {}",
+                backend_name,
+                "cte_column_alias_literals"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_cte_column_alias_renames_table_columns() {
+    // From: testing_data/cte/column_alias/02_cte_column_alias_renames_table_columns.json
+    // "CTE column alias list that renames the body's inferred columns: the outer query must see the aliased names"
+    let schema_sql = &["CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)"];
+
+    let query_sql = "-- @name GetRenamedColumns\n-- @returns :many\nWITH t(user_id, full_name) AS (SELECT id, name FROM users) SELECT user_id, full_name FROM t";
+
+    let catalog = scythe_core::catalog::Catalog::from_ddl(schema_sql).unwrap();
+    let query = scythe_core::parser::parse_query(query_sql).unwrap();
+    let analyzed = scythe_core::analyzer::analyze(&catalog, &query).unwrap();
+
+    assert_eq!(analyzed.name, "GetRenamedColumns", "query name");
+    assert_eq!(analyzed.command.to_string(), "many", "query command");
+    assert_eq!(analyzed.columns.len(), 2, "column count");
+    assert_eq!(analyzed.columns[0].name, "user_id", "column name");
+    assert_eq!(
+        analyzed.columns[0].neutral_type, "int32",
+        "column neutral_type for user_id"
+    );
+    assert!(!analyzed.columns[0].nullable, "column nullable for user_id");
+    assert_eq!(analyzed.columns[1].name, "full_name", "column name");
+    assert_eq!(
+        analyzed.columns[1].neutral_type, "string",
+        "column neutral_type for full_name"
+    );
+    assert!(!analyzed.columns[1].nullable, "column nullable for full_name");
+
+    // Codegen verification: all backends should produce valid output
+    let all_backends = [
+        "rust-sqlx",
+        "rust-tokio-postgres",
+        "python-psycopg3",
+        "python-asyncpg",
+        "typescript-postgres",
+        "typescript-pg",
+        "typescript-kysely",
+        "go-pgx",
+        "java-jdbc",
+        "java-r2dbc",
+        "kotlin-exposed",
+        "kotlin-jdbc",
+        "kotlin-r2dbc",
+        "csharp-npgsql",
+        "elixir-postgrex",
+        "elixir-ecto",
+        "ruby-pg",
+        "ruby-trilogy",
+        "php-pdo",
+        "php-amphp",
+    ];
+    for backend_name in &all_backends {
+        let backend = match scythe_codegen::get_backend(backend_name, "postgresql") {
+            Ok(b) => b,
+            Err(_) => continue, // skip unregistered backends
+        };
+        if let Ok(generated) = scythe_codegen::generate_with_backend(&analyzed, &*backend) {
+            let preamble = backend.file_preamble();
+            let header = backend.file_header();
+            let mut body = String::new();
+            if header.is_empty() {
+                body.push_str("#![allow(dead_code, unused_imports)]\n");
+            } else {
+                body.push_str(&header);
+                body.push('\n');
+            }
+            if let Some(ref s) = generated.enum_def {
+                body.push_str(s);
+                body.push('\n');
+            }
+            for def in &generated.nested_struct_defs {
+                body.push_str(&def.code);
+                body.push('\n');
+            }
+            if let Some(ref s) = generated.model_struct {
+                body.push_str(s);
+                body.push('\n');
+            }
+            if let Some(ref s) = generated.row_struct {
+                body.push_str(s);
+                body.push('\n');
+            }
+            if let Some(ref s) = generated.query_fn {
+                body.push_str(s);
+                body.push('\n');
+            }
+            let code = scythe_codegen::provenance::assemble_file(
+                &preamble,
+                &scythe_codegen::provenance::header_line(
+                    &*backend,
+                    env!("CARGO_PKG_VERSION"),
+                    "postgresql",
+                    "sch1:0123456789abcdef",
+                ),
+                &body,
+            );
+            if body.lines().count() > 1 {
+                // Only validate Rust syntax with syn for Rust backends
+                if *backend_name == "rust-sqlx" || *backend_name == "rust-tokio-postgres" {
+                    assert!(
+                        syn::parse_file(&code).is_ok(),
+                        "backend {} generated invalid Rust for {}",
+                        backend_name,
+                        "cte_column_alias_renames_table_columns"
+                    );
+                } else {
+                    // Structural validation for non-Rust backends
+                    let errors = scythe_codegen::validation::validate_structural(&code, backend_name);
+                    assert!(
+                        errors.is_empty(),
+                        "backend {} structural validation failed for {}: {:?}",
+                        backend_name,
+                        "cte_column_alias_renames_table_columns",
+                        errors
+                    );
+                }
+            }
+            assert!(
+                generated.row_struct.is_some() || generated.model_struct.is_some(),
+                "backend {} should produce a struct for {}",
+                backend_name,
+                "cte_column_alias_renames_table_columns"
+            );
+            assert!(
+                generated.query_fn.is_some(),
+                "backend {} should produce query_fn for {}",
+                backend_name,
+                "cte_column_alias_renames_table_columns"
+            );
+        }
+    }
+}
+
+#[test]
 fn test_cte_delete() {
     // From: testing_data/cte/cte_in_dml/03_cte_delete.json
     // "CTE used with DELETE ... USING for targeted deletes"

--- a/crates/scythe-core/src/analyzer/mod.rs
+++ b/crates/scythe-core/src/analyzer/mod.rs
@@ -1333,4 +1333,86 @@ SELECT json_agg(p.*) AS posts FROM posts p;",
 
         assert_eq!(result.nested_structs.len(), 1);
     }
+
+    /// The explicit column alias list on a CTE (`WITH t(a, b) AS ...`) must
+    /// name the CTE's columns even when the body projection carries no names
+    /// of its own — `SELECT 1` otherwise labels its column "unknown" and the
+    /// outer query's `SELECT a, b` fails with "column a does not exist".
+    #[test]
+    fn test_cte_column_alias_list_names_literal_columns() {
+        let catalog = make_catalog();
+        let query = parse_query(
+            "-- @name GetPair
+-- @returns :many
+WITH t(a, b) AS (SELECT 1, 2) SELECT a, b FROM t;",
+        )
+        .unwrap();
+
+        let result = analyze(&catalog, &query).unwrap();
+
+        let names: Vec<&str> = result.columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, ["a", "b"]);
+        assert!(result.columns.iter().all(|c| c.neutral_type == "int64"));
+    }
+
+    /// `SELECT *` over a CTE with an explicit column alias list expands to the
+    /// aliased names, not the body's inferred ones.
+    #[test]
+    fn test_cte_column_alias_list_consumed_by_select_star() {
+        let catalog = make_catalog();
+        let query = parse_query(
+            "-- @name GetPairStar
+-- @returns :many
+WITH t(a, b) AS (SELECT 1, 2) SELECT * FROM t;",
+        )
+        .unwrap();
+
+        let result = analyze(&catalog, &query).unwrap();
+
+        let names: Vec<&str> = result.columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, ["a", "b"]);
+    }
+
+    /// A CTE column alias list whose entry count disagrees with the body's
+    /// column count is a hard error (PostgreSQL rejects it too), not a
+    /// positional guess.
+    #[test]
+    fn test_cte_column_alias_count_mismatch_is_rejected() {
+        let catalog = make_catalog();
+        let query = parse_query(
+            "-- @name GetMismatch
+-- @returns :many
+WITH t(a) AS (SELECT 1, 2) SELECT * FROM t;",
+        )
+        .unwrap();
+
+        let err = analyze(&catalog, &query).unwrap_err();
+
+        assert!(
+            err.message
+                .contains("CTE column alias list has 1 entries but the CTE body produces 2 columns"),
+            "expected a column-alias-count diagnostic, got: {}",
+            err.message
+        );
+    }
+
+    /// Recursive CTEs resolve column references by name, so the alias list
+    /// must also apply to the anchor's seeded scope — `t(n)` must make `n`
+    /// referenceable inside the recursive term and in the outer query.
+    #[test]
+    fn test_recursive_cte_with_column_alias_list_names_columns() {
+        let catalog = make_catalog();
+        let query = parse_query(
+            "-- @name CountDown
+-- @returns :many
+WITH RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 10) SELECT n FROM t;",
+        )
+        .unwrap();
+
+        let result = analyze(&catalog, &query).unwrap();
+
+        let names: Vec<&str> = result.columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, ["n"]);
+        assert_eq!(result.columns[0].neutral_type, "int64");
+    }
 }

--- a/crates/scythe-core/src/analyzer/statements.rs
+++ b/crates/scythe-core/src/analyzer/statements.rs
@@ -6,6 +6,30 @@ use crate::errors::ScytheError;
 use super::helpers::*;
 use super::types::*;
 
+/// Overwrite a CTE body's inferred output column names with the CTE's explicit
+/// column alias list (`WITH t(a, b) AS ...`). A body projection that carries
+/// no names of its own — e.g. `SELECT 1` — otherwise names its columns
+/// "unknown". PostgreSQL requires the alias count to match the body's column
+/// count, so a mismatch is a hard error rather than a positional guess.
+fn apply_cte_alias_columns(
+    cte_alias: &ast::TableAlias,
+    mut cols: Vec<AnalyzedColumn>,
+) -> Result<Vec<AnalyzedColumn>, ScytheError> {
+    if cte_alias.columns.is_empty() {
+        return Ok(cols);
+    }
+    if cte_alias.columns.len() != cols.len() {
+        return Err(ScytheError::cte_column_alias_mismatch(
+            cte_alias.columns.len(),
+            cols.len(),
+        ));
+    }
+    for (col, alias) in cols.iter_mut().zip(&cte_alias.columns) {
+        col.name = alias.name.value.to_lowercase();
+    }
+    Ok(cols)
+}
+
 impl<'a> Analyzer<'a> {
     pub(super) fn analyze_statement(
         &mut self,
@@ -53,6 +77,10 @@ impl<'a> Analyzer<'a> {
                             // analyzed: seed `self.ctes` with the anchor-only shape
                             // first.
                             let base_cols = self.analyze_set_expr(left)?;
+                            // The alias list names the CTE's columns, and the
+                            // recursive term references them by name — apply it
+                            // before seeding the scope.
+                            let base_cols = apply_cte_alias_columns(&cte.alias, base_cols)?;
                             let scope_cols: Vec<ScopeColumn> = base_cols
                                 .iter()
                                 .map(|c| {
@@ -77,6 +105,10 @@ impl<'a> Analyzer<'a> {
                             // explicit NULL literal in a position the anchor fills
                             // with a NOT NULL column.
                             let full_cols = self.analyze_query(&cte.query)?;
+                            // The widened union shape takes its names from the left
+                            // arm; re-apply the alias list so the registered CTE
+                            // columns keep the declared names.
+                            let full_cols = apply_cte_alias_columns(&cte.alias, full_cols)?;
                             let widened_scope_cols: Vec<ScopeColumn> = full_cols
                                 .iter()
                                 .map(|c| {
@@ -94,6 +126,7 @@ impl<'a> Analyzer<'a> {
                     }
                 }
                 let cte_cols = self.analyze_query(&cte.query)?;
+                let cte_cols = apply_cte_alias_columns(&cte.alias, cte_cols)?;
                 let scope_cols: Vec<ScopeColumn> = cte_cols
                     .iter()
                     .map(|c| {
@@ -358,6 +391,14 @@ impl<'a> Analyzer<'a> {
 
         let mut seen_names: AHashSet<String> = AHashSet::new();
         for col in &columns {
+            // "unknown" is the placeholder name given to unaliased columns
+            // (e.g. `SELECT 1, 2` yields two of them), so several in one
+            // projection are normal rather than a genuine duplicate. A CTE
+            // column alias list replaces them when one exists; otherwise the
+            // name is left as-is. Only real, user-visible duplicates error.
+            if col.name == "unknown" {
+                continue;
+            }
             if !seen_names.insert(col.name.clone()) {
                 return Err(ScytheError::duplicate_alias(&col.name));
             }

--- a/crates/scythe-core/src/errors.rs
+++ b/crates/scythe-core/src/errors.rs
@@ -103,6 +103,17 @@ impl ScytheError {
         Self::new(ErrorCode::DuplicateAlias, format!("duplicate column alias \"{name}\""))
     }
 
+    /// The explicit column alias list on a CTE (`WITH t(a, b) AS ...`) has a
+    /// different entry count than the CTE body's output columns. PostgreSQL
+    /// rejects this at parse/plan time, so scythe must too — silently matching
+    /// by position would mislabel columns.
+    pub fn cte_column_alias_mismatch(alias_count: usize, column_count: usize) -> Self {
+        Self::new(
+            ErrorCode::ColumnCountMismatch,
+            format!("CTE column alias list has {alias_count} entries but the CTE body produces {column_count} columns"),
+        )
+    }
+
     pub fn invalid_recursion(msg: impl Into<String>) -> Self {
         Self::new(ErrorCode::InvalidRecursion, msg)
     }

--- a/testing_data/cte/column_alias/01_cte_column_alias_literals.json
+++ b/testing_data/cte/column_alias/01_cte_column_alias_literals.json
@@ -1,0 +1,29 @@
+{
+  "category": "cte/column_alias",
+  "description": "CTE with an explicit column alias list over a literal-only projection: the aliases must name the columns instead of the body's placeholder 'unknown' names",
+  "expected": {
+    "query": {
+      "columns": [
+        {
+          "name": "a",
+          "nullable": false,
+          "type": "int64"
+        },
+        {
+          "name": "b",
+          "nullable": false,
+          "type": "int64"
+        }
+      ],
+      "command": "many",
+      "name": "GetPair",
+      "params": []
+    },
+    "success": true
+  },
+  "name": "cte_column_alias_literals",
+  "query_sql": "-- @name GetPair\n-- @returns :many\nWITH t(a, b) AS (SELECT 1, 2) SELECT * FROM t",
+  "schema_sql": ["CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)"],
+  "source": "original",
+  "tags": ["cte", "column_alias", "regression"]
+}

--- a/testing_data/cte/column_alias/02_cte_column_alias_renames_table_columns.json
+++ b/testing_data/cte/column_alias/02_cte_column_alias_renames_table_columns.json
@@ -1,0 +1,29 @@
+{
+  "category": "cte/column_alias",
+  "description": "CTE column alias list that renames the body's inferred columns: the outer query must see the aliased names",
+  "expected": {
+    "query": {
+      "columns": [
+        {
+          "name": "user_id",
+          "nullable": false,
+          "type": "int32"
+        },
+        {
+          "name": "full_name",
+          "nullable": false,
+          "type": "string"
+        }
+      ],
+      "command": "many",
+      "name": "GetRenamedColumns",
+      "params": []
+    },
+    "success": true
+  },
+  "name": "cte_column_alias_renames_table_columns",
+  "query_sql": "-- @name GetRenamedColumns\n-- @returns :many\nWITH t(user_id, full_name) AS (SELECT id, name FROM users) SELECT user_id, full_name FROM t",
+  "schema_sql": ["CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)"],
+  "source": "original",
+  "tags": ["cte", "column_alias"]
+}

--- a/testing_data/cte/column_alias/03_cte_column_alias_count_mismatch.json
+++ b/testing_data/cte/column_alias/03_cte_column_alias_count_mismatch.json
@@ -1,0 +1,16 @@
+{
+  "category": "cte/column_alias",
+  "description": "CTE column alias list whose entry count disagrees with the body's column count must be rejected, matching PostgreSQL",
+  "expected": {
+    "success": false,
+    "error": {
+      "code": "COLUMN_COUNT_MISMATCH",
+      "message_contains": "CTE column alias list has 1 entries but the CTE body produces 2 columns"
+    }
+  },
+  "name": "cte_column_alias_count_mismatch",
+  "query_sql": "-- @name GetMismatch\n-- @returns :many\nWITH t(a) AS (SELECT 1, 2) SELECT * FROM t",
+  "schema_sql": ["CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL, email TEXT NOT NULL)"],
+  "source": "original",
+  "tags": ["cte", "column_alias", "error"]
+}


### PR DESCRIPTION
### What

CTE column alias lists (`WITH t(a, b) AS (...)`) are now applied to the analyzed scope. Previously the alias list was parsed but never consulted: CTE columns kept the names inferred from the body, so

- `WITH t(a, b) AS (SELECT 1, 2) SELECT a, b FROM t` failed with `column a does not exist` (both body columns are the `"unknown"` placeholder),
- `WITH t(a, b) AS (SELECT id, name FROM users)` reported `id`/`name` instead of `a`/`b`.

The alias list is applied at all three places where a CTE's columns are registered in `self.ctes`:

1. **Recursive anchor seed** — `WITH RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 10)`. The recursive term resolves column references by name, so `n` must be referenceable inside it; the alias is applied before seeding the scope.
2. **Widened recursive union shape** — the second analysis of the CTE body for the union widening pass; re-applied so the registered columns keep the declared names.
3. **Plain non-recursive path** — the fall-through registration in `analyze_statement`.

A count mismatch between the alias list and the body's column count is now a hard error — `COLUMN_COUNT_MISMATCH`, message `CTE column alias list has N entries but the CTE body produces M columns` — matching PostgreSQL, which rejects this at parse/plan time. Previously it would have silently mislabelled columns by position.

### Behavior note: duplicate-alias check

This exposed a related quirk. `SELECT 1, 2` produces two columns both named `"unknown"` — the placeholder for unaliased projection columns — and the duplicate-alias check in `analyze_select` rejected such projections as duplicates (`duplicate column alias "unknown"`). Because the placeholder exists only until a CTE alias list names the column (or nothing does), the check now skips columns named `"unknown"`. Genuine user-visible duplicates (`SELECT id AS x, name AS x`) still error exactly as before.

### Tests

- **4 unit tests** in `scythe-core/src/analyzer/mod.rs`:
  - literal-only projection with alias list → outer query sees `a`, `b`
  - `SELECT *` expansion over an aliased CTE
  - alias-count mismatch rejected with the new diagnostic
  - recursive CTE with alias list — `n` referenceable inside the recursive term and in the outer query
- **3 fixtures** under `testing_data/cte/column_alias/` (literals, rename-from-table-columns, count mismatch) driving the generated integration tests.

### Validation

Locally verified:

- `cargo test --workspace` — all pass (including the fixture-generated `test_cte` suite)
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all` — clean; committed generated tests match generator output after the CI's `regenerate + fmt` step