### PR TITLE
fix(core): make UNION unknown widening symmetric

### DIFF
--- a/crates/scythe-core/src/analyzer/helpers.rs
+++ b/crates/scythe-core/src/analyzer/helpers.rs
@@ -610,10 +610,17 @@ pub(super) fn find_nested_placeholder_id(neutral_type: &str) -> Option<u32> {
 /// approximate float always promotes straight to `float64`, mirroring
 /// PostgreSQL's implicit `numeric`/`integer` -> `float8` cast when the two
 /// meet in one expression (`1::numeric + 1.0::float4` is `float8`, not
-/// `float4`). Two genuinely incompatible types (`string` vs `int32`) fall
-/// through to the left argument, unchanged from the original behaviour.
+/// `float4`). A resolved type absorbs `unknown` in either position. Two
+/// genuinely incompatible resolved types (`string` vs `int32`) fall through
+/// to the left argument, unchanged from the original behaviour.
 pub(super) fn widen_type(a: &str, b: &str) -> String {
     if a == b {
+        return a.to_string();
+    }
+    if a == "unknown" {
+        return b.to_string();
+    }
+    if b == "unknown" {
         return a.to_string();
     }
     let int_rank = |t: &str| -> Option<u8> {
@@ -872,6 +879,21 @@ mod tests {
         assert_eq!(widen_type("float64", "decimal"), "float64");
         assert_eq!(widen_type("decimal", "float32"), "float64");
         assert_eq!(widen_type("float32", "decimal"), "float64");
+    }
+
+    #[test]
+    fn test_widen_type_is_symmetric_for_supported_types() {
+        let types = ["unknown", "int16", "int32", "int64", "decimal", "float32", "float64"];
+
+        for a in types {
+            for b in types {
+                assert_eq!(
+                    widen_type(a, b),
+                    widen_type(b, a),
+                    "widening {a} with {b} must not depend on operand order"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/scythe-core/src/analyzer/mod.rs
+++ b/crates/scythe-core/src/analyzer/mod.rs
@@ -1977,6 +1977,21 @@ SELECT x FROM a UNION SELECT NULL AS x FROM b;",
         assert_eq!(result.columns[0].neutral_type, "int32");
     }
 
+    /// The same widening must work when the untyped NULL is in the first arm.
+    /// UNION arm order cannot change the inferred result type.
+    #[test]
+    fn test_null_projection_in_first_union_arm_is_widened() {
+        let catalog = Catalog::from_ddl(&[
+            "CREATE TABLE a (id INTEGER PRIMARY KEY);",
+            "CREATE TABLE b (id INTEGER PRIMARY KEY, x INTEGER);",
+        ])
+        .unwrap();
+        let query =
+            parse_query("-- @name Widened\n-- @returns :many\nSELECT NULL AS x FROM a UNION SELECT x FROM b;").unwrap();
+        let result = analyze(&catalog, &query).expect("the first NULL arm must be widened by the second arm's int32");
+        assert_eq!(result.columns[0].neutral_type, "int32");
+    }
+
     /// When *neither* UNION arm resolves a real type, `widen_type`'s `a == b` fast
     /// path returns `"unknown"` untouched -- nothing in the query ever gave this
     /// column a type, so the taint must survive the widened `AnalyzedColumn` and


### PR DESCRIPTION
## Summary

Make `unknown` a neutral type during UNION widening regardless of which branch is analyzed first. This prevents a leading `NULL` branch from forcing later concrete values to remain `unknown`.

Closes #224

## Changes

- Absorb `unknown` symmetrically before numeric widening.
- Preserve the existing left-biased fallback for incompatible concrete types.
- Add a widening symmetry regression test and a mirrored NULL-first UNION analyzer test.

## Testing

- `cargo test -p scythe-core` (515 unit tests, 11 regression tests, and 1 doctest)
- `cargo fmt --all -- --check`
- `cargo clippy -p scythe-core --all-targets -- -D warnings -A clippy::collapsible_else_if`

The strict clippy command without that allowance still reports two pre-existing `collapsible_else_if` warnings in untouched files.

## Breaking Changes

None.
