### PR TITLE
build: raise tar floor to 7.5.21 in release/npm (GHSA-r292-9mhp-454m)

### DIFF
--- a/release/npm/package-lock.json
+++ b/release/npm/package-lock.json
@@ -20,7 +20,7 @@
       ],
       "dependencies": {
         "https-proxy-agent": "^9.1.0",
-        "tar": "^7.4.3",
+        "tar": "^7.5.21",
         "yauzl": "^3.1.3"
       },
       "bin": {

--- a/release/npm/package.json
+++ b/release/npm/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "https-proxy-agent": "^9.1.0",
-    "tar": "^7.4.3",
+    "tar": "^7.5.21",
     "yauzl": "^3.1.3"
   },
   "devDependencies": {}


### PR DESCRIPTION
Updates `tar` to address GHSA-r292-9mhp-454m (uncontrolled recursion in mapHas/filesFilter, fixed in 7.5.21).

Evidence:
- `release/npm/package.json` allowed `tar ^7.4.3`, so a fresh resolve can pick a version below the fix
- OSV reports GHSA-r292-9mhp-454m affects `tar < 7.5.21`
- manifest floor raised to `^7.5.21`; lockfile resolves `tar@7.5.22` (latest in range, also clear)

Validation:
- `npm ci` and `npm test` (`node --test`, 71 tests) pass in `release/npm`
- `npm ls tar` resolves `tar@7.5.22`

Scope: `release/npm/package.json` and `release/npm/package-lock.json` only.
